### PR TITLE
Make destination overwrite configurable.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,13 @@ Frozen-Flask accepts the following configuration values:
     ``_external=True``) or if your application is not at the root of its
     domain name.
     Defaults to ``'http://localhost/'``.
-    
+
+``FREEZER_OVERWRITE``
+    If set to `True`, Frozen-Flask will remove files in the destination
+    directory that were not built during the current freeze. This is intended
+    to clean up output files no longer needed on followup calls to
+    :meth:`Freezer.freeze`. Defaults to `True`.
+
 URL generators
 --------------
 

--- a/flaskext/frozen/__init__.py
+++ b/flaskext/frozen/__init__.py
@@ -59,6 +59,7 @@ class Freezer(object):
         if app:
             app.config.setdefault('FREEZER_DESTINATION', 'build')
             app.config.setdefault('FREEZER_BASE_URL', 'http://localhost/')
+            app.config.setdefault('FREEZER_OVERWRITE', True)
 
     def register_generator(self, function):
         """Register a function as an URL generator.
@@ -84,6 +85,7 @@ class Freezer(object):
 
     def freeze(self):
         """Clean the destination and build all URLs from generators."""
+        overwrite_destination = self.app.config['FREEZER_OVERWRITE']
         if not os.path.isdir(self.root):
             os.makedirs(self.root)
         previous_files = set(
@@ -99,13 +101,14 @@ class Freezer(object):
             seen_urls.add(url)
             new_filename = self._build_one(url)
             built_files.add(new_filename)
-        # Remove files from the previous build that are not here anymore.
-        for extra_file in previous_files - built_files:
-            os.remove(extra_file)
-            parent = os.path.dirname(extra_file)
-            if not os.listdir(parent):
-                # The directory is now empty, remove it.
-                os.removedirs(parent)
+        if overwrite_destination:
+            # Remove files from the previous build that are not here anymore.
+            for extra_file in previous_files - built_files:
+                os.remove(extra_file)
+                parent = os.path.dirname(extra_file)
+                if not os.listdir(parent):
+                    # The directory is now empty, remove it.
+                    os.removedirs(parent)
         return seen_urls
 
     def all_urls(self):

--- a/flaskext/frozen/tests/__init__.py
+++ b/flaskext/frozen/tests/__init__.py
@@ -167,6 +167,22 @@ class TestBuilder(unittest.TestCase):
             self.assertEquals(set(walk_directory(dest)), expected_files)
             self.assert_(not os.path.exists(os.path.join(dest, 'extra')))
 
+    def test_something_else_matters(self):
+        with self.built_app() as (temp, app, freezer, urls):
+            app.config['FREEZER_OVERWRITE'] = False
+            dest = app.config['FREEZER_DESTINATION']
+            expected_files = set(self.filenames.itervalues())
+            # No other files
+            self.assertEquals(set(walk_directory(dest)), expected_files)
+            # create an empty file
+            os.mkdir(os.path.join(dest, 'extra'))
+            open(os.path.join(dest, 'extra', 'extra.txt'), 'wb').close()
+            expected_files.add('extra/extra.txt')
+            # Verify that files in destination persist.
+            freezer.freeze()
+            self.assertEquals(set(walk_directory(dest)), expected_files)
+            self.assert_(os.path.exists(os.path.join(dest, 'extra')))
+
     def test_transitivity(self):
         with self.built_app() as (temp, app, freezer, urls):
             with temp_directory() as temp2:


### PR DESCRIPTION
In this patch, I kept the current behavior as the default, that the output directory is overwritten.  I'm not sure that's the best default, as it could lead to accidental deletion in tools that build sites using Frozen-Flask.

--rduplain
