### PR TITLE
Git-safe builds (ignore fnmatch strings when cleaning)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Patches and Suggestions
 - Rui Abreu Ferreira
 - Thomas Waldmann
 - vaus
+- Jim Gray

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -219,6 +219,16 @@ are accepted:
 
     .. versionadded:: 0.5
 
+``FREEZER_IGNORED_FILES``
+    A list of `fnmatch <http://docs.python.org/2/library/fnmatch.html>`_ pattern
+    strings to ignore when removing extra files (if ``FREEZER_REMOVE_EXTRA_FILES``
+    is ``True``). For example, setting
+    ``FREEZER_IGNORED_FILES = ['*/'+FREEZER_DESTINATION+'/*.git*','*/.git/*']``
+    would cause Frozen-Flask to avoid removing git-related files from the destination
+    directory. Defaults to []. 
+
+    .. versionadded:: 0.10
+
 ``FREEZER_DEFAULT_MIMETYPE``
     The MIME type that is assumed when it can not be determined from the
     filename extension. If you’re using the Apache web server, this should
@@ -329,6 +339,8 @@ Not released yet.
 
 Add the ``FREEZER_RELATIVE_URLS`` config and the :func:`relative_url_for`
 function.
+
+Add the ``FREEZER_IGNORED_FILES`` config.
 
 
 Version 0.9

--- a/flask_frozen/__init__.py
+++ b/flask_frozen/__init__.py
@@ -21,6 +21,7 @@ import urllib
 import warnings
 import collections
 import posixpath
+import fnmatch
 from unicodedata import normalize
 from threading import Lock
 from contextlib import contextmanager
@@ -110,6 +111,7 @@ class Freezer(object):
             app.config.setdefault('FREEZER_DESTINATION', 'build')
             app.config.setdefault('FREEZER_BASE_URL', 'http://localhost/')
             app.config.setdefault('FREEZER_REMOVE_EXTRA_FILES', True)
+            app.config.setdefault('FREEZER_IGNORED_FILES', [])
             app.config.setdefault('FREEZER_DEFAULT_MIMETYPE',
                                   'application/octet-stream')
             app.config.setdefault('FREEZER_IGNORE_MIMETYPE_WARNINGS', False)
@@ -143,6 +145,7 @@ class Freezer(object):
     def freeze(self):
         """Clean the destination and build all URLs from generators."""
         remove_extra = self.app.config['FREEZER_REMOVE_EXTRA_FILES']
+        ignored_files = self.app.config['FREEZER_IGNORED_FILES']
         if not os.path.isdir(self.root):
             os.makedirs(self.root)
         previous_files = set(
@@ -166,7 +169,12 @@ class Freezer(object):
         self._check_endpoints(seen_endpoints)
         if remove_extra:
             # Remove files from the previous build that are not here anymore.
-            for extra_file in previous_files - built_files:
+            extra_files = previous_files - built_files
+            if len(ignored_files):
+                # If there are ignored file strings, remove matches from extra_files
+                for pattern in ignored_files:
+                    extra_files -= set(fnmatch.filter(extra_files, pattern))
+            for extra_file in extra_files:
                 os.remove(extra_file)
                 parent = os.path.dirname(extra_file)
                 if not os.listdir(parent):


### PR DESCRIPTION
Sorry about the duplicate request. Something got corrupted in my version, then my attempts to fix it caused Github to auto-close the request.

This adds a `FREEZER_IGNORED_FILES` config which will cause build directory cleaning to skip any files which fnmatch a string in the ignored list. It works by removing matching entries from the set of extra files.

Since Frozen-Flask doesn't copy over non-generated files, no further modifications are necessary to make it git-safe. Also, I don't think that it should be changed to copy over favicon.ico and etc., in keeping with Flask's minimalism. This should be left up to the calling code.
