### PR TITLE
Add an ignored files config to prevent freezing from overwriting/removing files

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -244,6 +244,13 @@ are accepted:
 
     .. versionadded:: 0.10
 
+``FREEZER_IGNORED_FILES``
+    A list of files and directories relative to the destination directory that
+    are to be ignored during freezing. This prevents files and directories that were not built durring the current freeze from being removed or overwritten. Defaults to ``[]``.
+
+    .. versionadded:: 0.10
+
+
 
 .. _mime-types:
 


### PR DESCRIPTION
I am using Frozen-Flask to create my blog which I publish through Github Pages. The problem is that freezing removes all of the files in the `.git` directory of the blog's github repo which kills the repository. I could build to a different destination and then copy over all of the files to my github repo, but that is a tedious and error prone process. Instead, it would be nice to have a config setting that would allow you to specify files and directories to ignore during the freezing process (something akin to the .gitignore file).

The changes I've made in this pull request introduce a new config setting `FREEZER_IGNORED_FILES` to fix this issue. The ignored files setting takes a list of file and directory names (relative to the destination directory) and expands those into a list of ignored file paths. 

So, for example, if you wanted to ignore all files within the `.git` directory of a Git repo and a `CNAME` file within the top level of the destination directory, you could add the following to your script:

``` python
FREEZER_IGNORED_FILES = ['.git', 'CNAME']
```
