### PR TITLE
Add an option to allow freeze to continue when a 404 error is returned

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -274,6 +274,16 @@ are accepted:
 
     .. versionadded:: 0.12
 
+``FREEZER_IGNORE_404_NOT_FOUND``
+    If set to ``True`` (defaults False), Frozen-Flask won't stop freezing when
+    404 error is returned by your application.
+    In this case, a warning will be printed on stdout and the static page will
+    be generated using your 404 error page handler or flask's default one.
+    This can be usefull during development phase if you have already referenced
+    pages wich aren't written yet.
+
+    .. versionadded:: 0.12
+
 .. _mime-types:
 
 Filenames and MIME types


### PR DESCRIPTION
It can be usefull when your application is in development.
I have named it FREEZER_IGNORE_404_NOT_FOUND.
The new option is covered by the documentation and the unit tests.
I hope it will be usefull.
Best Regards.
