### PR TITLE
Add option to warn or error on redirects.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,10 +14,12 @@ Patches and Suggestions
 - Christopher Roach
 - David Baumgold
 - Glwadys Fayolle
+- Google Inc.
 - Jim Gray
 - Jochen Kupperschmidt
 - Jökull Sólberg Auðunsson
 - Ron DuPlain
 - Rui Abreu Ferreira
 - Thomas Waldmann
+- Tim Swast <swast@google.com>
 - vaus

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -289,10 +289,19 @@ are accepted:
     404 error is returned by your application.
     In this case, a warning will be printed on stdout and the static page will
     be generated using your 404 error page handler or flask's default one.
-    This can be usefull during development phase if you have already referenced
-    pages wich aren't written yet.
+    This can be useful during development phase if you have already referenced
+    pages which aren't written yet.
 
     .. versionadded:: 0.12
+
+``FREEZER_REDIRECT_POLICY``
+    The policy for handling redirects. The default is ``'follow'`` which means
+    that when a redirect response is encountered it will follow it to get the
+    content from the redirected location. ``'ignore'`` will not stop freezing,
+    but no content will appear in the redirected location. ``'error'`` will
+    raise an exception if a redirect is encountered.
+
+    .. versionadded:: 0.13
 
 .. _mime-types:
 

--- a/flask_frozen/test_app/__init__.py
+++ b/flask_frozen/test_app/__init__.py
@@ -13,7 +13,7 @@
 import os.path
 from functools import partial
 
-from flask import Flask, url_for
+from flask import Flask, url_for, redirect
 from flask_frozen import Freezer
 
 from .admin import admin_blueprint
@@ -36,6 +36,10 @@ def create_app(defer_init_app=False, freezer_kwargs=None):
     def index():
         return ('Main index ' +
                 url_for('product', product_id='5', revision='b12ef20'))
+
+    @app.route('/redirect/')
+    def redirected_page():
+        return redirect('/')
 
     @app.route('/page/<name>/')
     def page(name):


### PR DESCRIPTION
A meta refresh tag can simulate a redirect

```
<meta http-equiv="refresh" content="0; url=new-page.html">
```

This seems more appropriate than the default behavior of following the
redirect and duplicating the content.

Adds a test with a redirect to test current duplicate content behavior
as well as redirecting via an HTML meta refresh.

In some sense, this

Fixes https://github.com/SimonSapin/Frozen-Flask/issues/42