### PR TITLE
Remove the `--use-mirrors` option from the PIP command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
   - "pypy"
 
 install:
-  - pip install --use-mirrors -e .
+  - pip install -e .
 
 script: python -m flask_frozen.tests


### PR DESCRIPTION
The `--use-mirrors` option was removed from the PIP command. The DNS
alias mirrors for PyPI have been removed.
https://pypi.python.org/mirrors

Hopefully this makes the Travis builds happy again.