### PR TITLE
Update Python 3 versions this is tested on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
   - "pypy"
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,15 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, pypy
+envlist = py26, py27, py34, py35, py36, pypy, pypy3
 [testenv]
 commands=python -m flask_frozen.tests
 changedir=docs


### PR DESCRIPTION
 * Add 3.4, 3.5, 3.6, pypy3
 * Remove 3.3

 * In tox
 * On Travis CI
 * In setup.py classifiers

Note that pypy3 is not added on Travis CI yet, as Travis CI has an old version that has Python 3.2 and fails.