### PR TITLE
Add a common superclass for all internal warnings

### DIFF
--- a/flask_frozen/__init__.py
+++ b/flask_frozen/__init__.py
@@ -45,19 +45,23 @@ except NameError:  # Python 3
     basestring = str
 
 
-class MissingURLGeneratorWarning(Warning):
+class FrozenFlaskWarning(Warning):
     pass
 
 
-class MimetypeMismatchWarning(Warning):
+class MissingURLGeneratorWarning(FrozenFlaskWarning):
     pass
 
 
-class NotFoundWarning(Warning):
+class MimetypeMismatchWarning(FrozenFlaskWarning):
     pass
 
 
-class RedirectWarning(Warning):
+class NotFoundWarning(FrozenFlaskWarning):
+    pass
+
+
+class RedirectWarning(FrozenFlaskWarning):
     pass
 
 

--- a/flask_frozen/tests.py
+++ b/flask_frozen/tests.py
@@ -23,8 +23,8 @@ from unicodedata import normalize
 from warnings import catch_warnings
 
 from flask_frozen import (Freezer, walk_directory,
-    MissingURLGeneratorWarning, MimetypeMismatchWarning, NotFoundWarning,
-    RedirectWarning)
+    FrozenFlaskWarning, MissingURLGeneratorWarning, MimetypeMismatchWarning,
+    NotFoundWarning, RedirectWarning)
 from flask_frozen import test_app
 
 try:
@@ -405,6 +405,25 @@ class TestFreezer(unittest.TestCase):
             freezer.freeze()
             with open(os.path.join(temp, 'skipped.html')) as f:
                 self.assertEqual(f.read(), '6*9')
+
+
+class TestWarnings(unittest.TestCase):
+    def test_warnings_share_common_superclass(self):
+        with catch_warnings(record=True) as logged_warnings:
+            # ignore all warnings:
+            warnings.simplefilter('ignore')
+            # but don't ignore FrozenFlaskWarning
+            warnings.filterwarnings('always', category=FrozenFlaskWarning)
+            # warn each of our warnings:
+            warnings_frozen_flask = (MissingURLGeneratorWarning,
+                                     MimetypeMismatchWarning,
+                                     NotFoundWarning,
+                                     RedirectWarning)
+            for warning in warnings_frozen_flask:
+                warnings.warn('test', warning)
+            # warn something different:
+            warnings.warn('test', PendingDeprecationWarning)
+            self.assertEqual(len(logged_warnings), len(warnings_frozen_flask))
 
 
 class TestInitApp(TestFreezer):


### PR DESCRIPTION
This allows the consumer to filter all Frozen Flask warnings easily.

See https://github.com/pyvec/elsa/pull/34

Compare (previously needed):

```python
for warning in (flask_frozen.MimetypeMismatchWarning,
                flask_frozen.MissingURLGeneratorWarning,
                flask_frozen.NotFoundWarning,
                flask_frozen.RedirectWarning):
    warnings.filterwarnings('error', category=warning)
```

With (after this PR):

```python
warnings.filterwarnings('error', category=flask_frozen.FrozenFlaskWarning)
```