### PR TITLE
Travis CI: Run on PyPy 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
+  - "pypy3.3-5.2-alpha1"
 
 install:
   - pip install -e .


### PR DESCRIPTION
Previously in c78bbc3271af6c66dc6a6d3d0df4815264fa801b
pypy3 was not added as the version on Travis CI is too old (Python 3.2).

This is an undocumented but working setting that has PyPy 3 with Python 3.3.