### PR TITLE
Add .freeze_yield() that freezes the app and yields URLs and paths

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,9 @@ sys.path.append(os.path.abspath('_themes'))
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']
 
-intersphinx_mapping = {'flask': ('http://flask.pocoo.org/docs/', None)}
+intersphinx_mapping = {'flask': ('http://flask.pocoo.org/docs/', None),
+                       'python': ('https://docs.python.org/3/', None),
+                       'click': ('http://click.pocoo.org/', None)}
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -379,7 +379,8 @@ API reference
 -------------
 
 .. autoclass:: Freezer
-    :members: init_app, root, register_generator, all_urls, freeze, serve, run
+    :members: init_app, root, register_generator, all_urls, freeze,
+              freeze_yield, serve, run
 
 .. autofunction:: walk_directory
 


### PR DESCRIPTION
This change enables the user of Frozen-Flask to iterate over the URLs beeing frozen and visualize the progress (i.e. by printing the URLs to the stdout or using some kind of progressbar).