### PR TITLE
can yield a last_modified time for URLs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -127,6 +127,11 @@ You can specify a different endpoint by yielding a ``(endpoint, values)``
 tuple instead of just ``values``, or you can by-pass ``url_for`` and simply
 yield URLs as strings.
 
+You can avoid re-freezing URLs by yielding a tuple ``(endpoint, values, time)``, 
+where ``time`` is a ``datetime.datetime`` object. The URL will only be frozen
+if the corresponding output file doesn't exist, or was last modified earlier 
+than ``time``.
+
 Also, generator functions do not have to be `Python generators
 <http://docs.python.org/glossary.html#term-generator>`_ using ``yield``,
 they can be any callable and return any iterable object.

--- a/flask_frozen/__init__.py
+++ b/flask_frozen/__init__.py
@@ -16,6 +16,7 @@ __all__ = ['Freezer', 'walk_directory', 'relative_url_for']
 
 VERSION = '0.16'
 
+import datetime
 import os.path
 import mimetypes
 import warnings
@@ -27,7 +28,6 @@ from threading import Lock
 from contextlib import contextmanager
 from collections import Mapping, namedtuple
 from posixpath import relpath as posix_relpath
-import datetime
 
 try:
     from urllib import unquote

--- a/flask_frozen/tests.py
+++ b/flask_frozen/tests.py
@@ -508,18 +508,18 @@ class TestLastModifiedGenerator(TestFreezer):
 
             @freezer.register_generator
             def view_post():
-                yield 'show_time', {'when': 'epoch'}, datetime.datetime.fromtimestamp(0)
+                yield 'show_time', {'when': 'epoch'}, datetime.datetime.fromtimestamp(100000)
                 yield 'show_time', {'when': 'now'}, datetime.datetime.now()
 
             freezer.freeze()
 
-            first_mtimes = {k:os.path.getmtime(os.path.join(temp,'time',k,'index.html')) for k in ['epoch', 'now']}
+            first_mtimes = dict((k,os.path.getmtime(os.path.join(temp,'time',k,'index.html'))) for k in ['epoch', 'now'])
 
             time.sleep(2)
 
             freezer.freeze()
 
-            second_mtimes = {k:os.path.getmtime(os.path.join(temp,'time',k,'index.html')) for k in ['epoch', 'now']}
+            second_mtimes = dict((k,os.path.getmtime(os.path.join(temp,'time',k,'index.html'))) for k in ['epoch', 'now'])
 
             self.assertEqual(first_mtimes['epoch'],second_mtimes['epoch'])
             self.assertNotEqual(first_mtimes['now'],second_mtimes['now'])


### PR DESCRIPTION
A fairly simple way of allowing incremental builds.

A generator can yield a tuple (url, values, last_modified), where
last_modified is a datetime.

If the corresponding output file already exists and is at least as new
as the last_modified time, it isn't rebuilt. If it doesn't exist, or
it's older than the last_modified time, it is rebuilt.