### PR TITLE
Added a hook to process page content while freezing

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -391,7 +391,7 @@ API reference
 
 .. autoclass:: Freezer
     :members: init_app, root, register_generator, all_urls, freeze,
-              freeze_yield, serve, run
+              freeze_yield, serve, run, process_page_content
 
 .. autofunction:: walk_directory
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -397,6 +397,17 @@ API reference
 
 .. autofunction:: relative_url_for
 
+Building documentation locally
+------------------------------
+
+To build documentation locally, you'll have to install sphinx and the Flask sphinx theme::
+
+  python -m pip install sphinx Flask-Sphinx-Themes
+
+Then, use the setuptools command to build the documentation, which will be generated in `docs/_build/`::
+
+  python setup.py build_sphinx
+
 Changelog
 ---------
 

--- a/flask_frozen/__init__.py
+++ b/flask_frozen/__init__.py
@@ -356,6 +356,9 @@ class Freezer(object):
 
         # Write the file, but only if its content has changed
         content = response.data
+
+        self.process_page_content(url, content)
+
         if os.path.isfile(filename):
             with open(filename, 'rb') as fd:
                 previous_content = fd.read()
@@ -369,6 +372,11 @@ class Freezer(object):
 
         response.close()
         return filename
+
+    def process_page_content(self, url, content):
+        """
+        Can be used to access rendered content while freezing.
+        """
 
     def urlpath_to_filepath(self, path):
         """


### PR DESCRIPTION
If a developer wanted to access the rendered content while freezing, they would have to put the whole `_build_one` method in the subclass and add the code processing the content there, which quite obviously isn't a great idea. Any updates to the method in Frozen-Flask would be lost once the package would be upgraded and it's also not very pretty.

With my update, the developer would only need to override the new `process_page_content` method to accomplish the same thing.

I was struggling for a bit to build the documentation locally so I could check the output so I decided to document the procedure. I can put it in a separate PR if you'd like.