### PR TITLE
Ignore static rules with not exactly one argument

### DIFF
--- a/flask_frozen/__init__.py
+++ b/flask_frozen/__init__.py
@@ -430,6 +430,12 @@ class Freezer(object):
         assert unwrap_method(Blueprint.send_static_file) is send_static_file
 
         for rule in self.app.url_map.iter_rules():
+            # static rules should have exactly one argument, the filename
+            # however, additional arguments can be happen because of
+            # url_prefixes, or url_defaults. We skip those.
+            if len(rule.arguments) != 1:
+                continue
+
             view = self.app.view_functions[rule.endpoint]
             if unwrap_method(view) is send_static_file:
                 yield rule.endpoint


### PR DESCRIPTION
I came across this when I tried to freeze one of my flask apps with frozen-flask, where I did use url_defaults and url_value_preprocessor. It took me a while to figure out, why Frozen-flask did react like it did.

This just skips those rules, the logic from the value_preprocessor needs to be captured in a custom generator.