### PR TITLE
Improves readability of documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,7 +110,7 @@ If, for some reason, some products pages are not linked from another page
 (or these links are not built by :func:`~flask.url_for`), Frozen-Flask will
 not find them.
 
-To tell Frozen-Flask about them, write an URL generator and put it after
+To tell Frozen-Flask about them, write a URL generator and put it after
 creating your :class:`Freezer` instance and before calling
 :meth:`~Freezer.freeze`::
 
@@ -524,7 +524,7 @@ Released on 2011-07-24.
   register the app later with :meth:`Freezer.init_app`.
 * The ``FREEZER_DESTINATION`` directory is created if it does not exist.
 * New configuration: ``FREEZER_REMOVE_EXTRA_FILES``
-* Warn if an URL generator seems to be missing. (ie. if no URL was generated
+* Warn if a URL generator seems to be missing. (ie. if no URL was generated
   for a given endpoint.)
 * Write Unicode filenames instead of UTF-8. Non-ASCII filenames are often
   undefined territory anyway.


### PR DESCRIPTION
From Purdue Online Writing Lab:

When "u" makes the same sound as the "y" in "you," or "o" makes the same sound as "w" in "won," then a is used. The word-initial "y" sound ("unicorn") is a glide [j] phonetically, which has consonantal properties; consequently, it is treated as a consonant, requiring "a."

https://owl.purdue.edu/owl/general_writing/grammar/articles_a_versus_an.html