### PR TITLE
Support unquoting URLs that contain multi-byte unicode characters

### DIFF
--- a/flask_frozen/__init__.py
+++ b/flask_frozen/__init__.py
@@ -35,8 +35,8 @@ except ImportError:
     from collections import Mapping  # Python 2.7
 
 try:
-    from urllib import unquote
     from urlparse import urlsplit
+    from werkzeug.urls import url_unquote as unquote
 except ImportError:  # Python 3
     from urllib.parse import urlsplit, unquote
 


### PR DESCRIPTION
The Python 2.7 `urllib.unquote` implementation does not handle decoding non-ASCII characters; instead use werkzeug's encoding-aware implementation.

Fixes #103