### PR TITLE
Enable Python 3.9 in continuous integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [2.7, 3.6, 3.7, 3.8, 3.9, pypy3]
+        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [2.7, 3.6, 3.7, 3.8, pypy3]
+        python: [2.7, 3.6, 3.7, 3.8, 3.9, pypy3]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+        python: [2.7, 3.6, 3.7, 3.8, pypy3]
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
- Remove Python 3.5 continuous integration builds (it's now past end-of-life according to the Python [download page](https://www.python.org/downloads/))
- Enable Python 3.9