### PR TITLE
You can now specifiy paths/endpoints to avoid with the FREEZER_BLACKLIST setting and standard fnmatching.

### DIFF
--- a/flask_frozen/__init__.py
+++ b/flask_frozen/__init__.py
@@ -114,6 +114,7 @@ class Freezer(object):
             self.url_for_logger = UrlForLogger(app)
             app.config.setdefault('FREEZER_DESTINATION', 'build')
             app.config.setdefault('FREEZER_DESTINATION_IGNORE', [])
+            app.config.setdefault('FREEZER_BLACKLIST', [])
             app.config.setdefault('FREEZER_STATIC_IGNORE', [])
             app.config.setdefault('FREEZER_BASE_URL', None)
             app.config.setdefault('FREEZER_REMOVE_EXTRA_FILES', True)
@@ -271,6 +272,9 @@ class Freezer(object):
                     url = parsed_url.path
                     if not isinstance(url, unicode):
                         url = url.decode(url_encoding)
+                    # Skip if a blacklisted endpoint or url
+                    if any(fnmatch(url, pattern) or fnmatch(endpoint, pattern) for pattern in self.app.config['FREEZER_BLACKLIST']):
++                        continue
                     yield url, endpoint, last_modified
 
     def _check_endpoints(self, seen_endpoints):


### PR DESCRIPTION
This is supposed to allow you to blacklist urls and endpoints from freezer generation. 
It checks if the url or path of the generated item is in the FREEZER_BLACKLIST setting(a list of fnmatches) and skips it if so.

See https://github.com/Frozen-Flask/Frozen-Flask/issues/66