### PR TITLE
Pin Flask to versions before 2.0

### DIFF
--- a/flask_frozen/__init__.py
+++ b/flask_frozen/__init__.py
@@ -14,7 +14,7 @@
 
 __all__ = ['Freezer', 'walk_directory', 'relative_url_for']
 
-VERSION = '0.16'
+VERSION = '0.17'
 
 import datetime
 import os.path

--- a/flask_frozen/tests.py
+++ b/flask_frozen/tests.py
@@ -30,6 +30,7 @@ from flask_frozen import (Freezer, walk_directory,
     FrozenFlaskWarning, MissingURLGeneratorWarning, MimetypeMismatchWarning,
     NotFoundWarning, RedirectWarning)
 from flask_frozen import test_app
+import flask_frozen
 
 try:
     unicode
@@ -528,7 +529,8 @@ class TestLastModifiedGenerator(TestFreezer):
 
 class TestPythonCompatibilityWarnings(unittest.TestCase):
     def test_importing_collections(self):
-        ps = subprocess.check_output([sys.executable, 'flask_frozen/__init__.py'],
+        flask_script_path = flask_frozen.__file__
+        ps = subprocess.check_output([sys.executable, flask_script_path],
                                      stderr=subprocess.STDOUT)
         stderr = ps.decode('utf-8').lower()
         assert 'deprecationwarning' not in stderr

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'Flask >= 1.1.0',
+        'Flask >= 1.1.0, < 2.0',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
This fixes tests (#106) and works around Flask 2.0 incompatibility (#113) by pinning the Flask version.
I've also increased the Frozen-Flask version so it can be released to PyPI.