### PR TITLE
Flask 2.x: ensure that the 'static' endpoint continues to be emitted by '_static_rules_endpoints' method

### DIFF
--- a/flask_frozen/__init__.py
+++ b/flask_frozen/__init__.py
@@ -438,6 +438,10 @@ class Freezer(object):
             view = self.app.view_functions[rule.endpoint]
             if unwrap_method(view) is send_static_file:
                 yield rule.endpoint
+            # This check for the string literal 'static' relies on Flask
+            # implementation internals and is fragile
+            elif rule.endpoint == 'static':
+                yield rule.endpoint
 
     def static_files_urls(self):
         """
@@ -445,7 +449,7 @@ class Freezer(object):
         """
         for endpoint in self._static_rules_endpoints():
             view = self.app.view_functions[endpoint]
-            app_or_blueprint = method_self(view)
+            app_or_blueprint = method_self(view) or self.app
             root = app_or_blueprint.static_folder
             ignore = self.app.config['FREEZER_STATIC_IGNORE']
             if root is None or not os.path.isdir(root):
@@ -566,8 +570,12 @@ def method_self(method):
         # Python 2
         return method.im_self
     except AttributeError:
-        # Python 3
-        return method.__self__
+        try:
+            # Python 3
+            return method.__self__
+        except AttributeError:
+            # Not a method.
+            return
 
 
 @contextmanager

--- a/flask_frozen/__init__.py
+++ b/flask_frozen/__init__.py
@@ -438,8 +438,11 @@ class Freezer(object):
             view = self.app.view_functions[rule.endpoint]
             if unwrap_method(view) is send_static_file:
                 yield rule.endpoint
-            # This check for the string literal 'static' relies on Flask
-            # implementation internals and is fragile
+            # Flask has historically always used the literal string 'static' to
+            # refer to the static file serving endpoint.  Arguably this could
+            # be considered fragile; equally it is unlikely to change.  See
+            # https://github.com/pallets/flask/discussions/4136 for some
+            # related discussion.
             elif rule.endpoint == 'static':
                 yield rule.endpoint
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'Flask >= 1.1.0, < 2.0',
+        'Flask >= 1.1.0',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
This is an attempt to fix #113, and addresses an incompatibility between existing versions of `Frozen-Flask` and `Flask` 2.x.

Thanks are due to @tachyondecay for analysis and suggestions in https://github.com/pallets/flask/discussions/4136 which are included here.

Tests should pass for both `Flask` < 2.0 and also for `Flask` >= 2.0 on this pull request.  To illustrate that, I'll open this pull request with the existing `Flask < 2.0` version pin in place, before pushing a subsequent commit to remove that pin.