### PR TITLE
Document and test that the 'follow' redirect policy doesn't support external redirects

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -302,7 +302,7 @@ are accepted:
 ``FREEZER_REDIRECT_POLICY``
     The policy for handling redirects. This can be:
     * ``'follow'`` (default): when a redirect response is encountered,
-      Frozen-Flask it will follow it to get the content from the redirected
+      Frozen-Flask will follow it to get the content from the redirected
       location. Note that redirects to external pages are not supported.
     * ``'ignore'``: freezing will continue, but no content will appear in the
       redirecting location.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -300,11 +300,13 @@ are accepted:
     .. versionadded:: 0.12
 
 ``FREEZER_REDIRECT_POLICY``
-    The policy for handling redirects. The default is ``'follow'`` which means
-    that when a redirect response is encountered it will follow it to get the
-    content from the redirected location. ``'ignore'`` will not stop freezing,
-    but no content will appear in the redirected location. ``'error'`` will
-    raise an exception if a redirect is encountered.
+    The policy for handling redirects. This can be:
+    * ``'follow'`` (default): when a redirect response is encountered,
+      Frozen-Flask it will follow it to get the content from the redirected
+      location. Note that redirects to external pages are not supported.
+    * ``'ignore'``: freezing will continue, but no content will appear in the
+      redirecting location.
+    * ``'error'`` : raise an exception if a redirect is encountered.
 
     .. versionadded:: 0.13
 

--- a/flask_frozen/tests.py
+++ b/flask_frozen/tests.py
@@ -26,6 +26,8 @@ from warnings import catch_warnings
 import sys
 import subprocess
 
+from flask import redirect
+
 from flask_frozen import (Freezer, walk_directory,
     FrozenFlaskWarning, MissingURLGeneratorWarning, MimetypeMismatchWarning,
     NotFoundWarning, RedirectWarning)
@@ -410,6 +412,17 @@ class TestFreezer(unittest.TestCase):
             freezer.freeze()
             with open(os.path.join(temp, 'skipped.html')) as f:
                 self.assertEqual(f.read(), '6*9')
+
+    def test_error_external_redirect(self):
+        with self.make_app() as (temp, app, freezer):
+            app.config['FREEZER_REDIRECT_POLICY'] = 'follow'
+            # Add a new endpoint with external redirect
+            @app.route('/redirect/ext/')
+            def external_redirected_page():
+                return redirect('https://github.com/Frozen-Flask/Frozen-Flask')
+
+            with self.assertRaises(RuntimeError):
+                freezer.freeze()
 
 class TestWarnings(unittest.TestCase):
     def test_warnings_share_common_superclass(self):


### PR DESCRIPTION
Frozen-Flask raises a RuntimeError by default when it encounters a redirect ot an external page.
Here is a documentation note and a test for this behavior.