### PR TITLE
docs: fix simple typo, unmodifies -> unmodified

### DIFF
--- a/flask_frozen/__init__.py
+++ b/flask_frozen/__init__.py
@@ -611,7 +611,7 @@ class UrlForLogger(object):
                 self.logged_calls.append((endpoint, values.copy()))
 
         # Do not use app.url_defaults() as we want to insert at the front
-        # of the list to get unmodifies values.
+        # of the list to get unmodified values.
         self.app.url_default_functions.setdefault(None, []).insert(0, logger)
 
     def __enter__(self):


### PR DESCRIPTION
There is a small typo in flask_frozen/__init__.py.

Should read `unmodified` rather than `unmodifies`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md