### PR TITLE
Stepping down as a maintainer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,14 +26,10 @@ Contributing
 * Do your changes, make sure tests pass
 * Send a Pull Request to the upstream repository
 
-Maintainers
------------
+Status
+------
 
-- `@honzajavorek <https://github.com/honzajavorek>`__ - Dedicates around an hour per week or less, which means just occasional PR reviews, releases and minor fixes.
-- `@tswast <https://github.com/tswast>`__ - Occasional `Deus ex machina <https://en.wikipedia.org/wiki/Deus_ex_machina>`__.
-- `@SimonSapin <https://github.com/SimonSapin>`__ - Inactive, but has his picture in our Hall of Fame for creating the project.
-
-If you want to join the list, you can generally qualify yourself by contributing to the project with a few Pull Requests (don't forget tests).
+**The project doesn't have an active maintainer as of now.** If you want to become one, please contact `@honzajavorek <https://github.com/honzajavorek>`__ and `@tswast <https://github.com/tswast>`__. `@SimonSapin <https://github.com/SimonSapin>`__ is pretty much inactive, but has his picture in our Hall of Fame for creating the project.
 
 License
 -------


### PR DESCRIPTION
I wasn't able to dedicate time to the project in a way which would satisfy me or the contributors. Every time I've got a notification about a new PR here, all I felt for the past year or so could be described pretty much as guilt. I think I shouldn't give false expectations and I'm officially stepping down as a maintainer.

This proposed change to the README would clearly communicate to the contributors that if they send a PR, there won't be anyone reviewing or merging it. This is a fact already for some time and we should be transparent about it, not to waste people's time and enthusiasm to open source.