### PR TITLE
Fix `pyproject.toml` not to install tests as top-level package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ path = 'flask_frozen/__init__.py'
 exclude = ['.*']
 
 [tool.hatch.build.targets.wheel]
-exclude = ['docs']
+exclude = ['docs', 'tests']
 
 [tool.hatch.envs.doc]
 features = ['doc']


### PR DESCRIPTION
Fix the `pyproject.toml` configuration not to install e.g.:

    /usr/lib/python3.11/site-packages/tests