### PR TITLE
Fix finding packages witch hatchling >= 1.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ path = 'flask_frozen/__init__.py'
 exclude = ['.*']
 
 [tool.hatch.build.targets.wheel]
-exclude = ['docs', 'tests']
+packages = ['flask_frozen']
 
 [tool.hatch.envs.doc]
 features = ['doc']


### PR DESCRIPTION
Explicitly specify the package name to install, in order to fix compatibility with `hatchling >= 1.19.0`.  Starting with this version (though Frozen-Flask is affected since 1.20.0, due to a bug in hatchling), it is necessary to explicitly select packages if they do not

As of hatchling >= 1.19.0, it is necessary to explicitly specify `packages` to use if they do not fit the default heuristics (i.e. are disjoint from the project name).

Since the package is now specified explicitly, the `exclude` rules are no longer necessary.